### PR TITLE
Only delete char when blank or punctuation around cursor.

### DIFF
--- a/deno-bridge-jieba.el
+++ b/deno-bridge-jieba.el
@@ -133,8 +133,7 @@
    ((or
      (deno-bridge-jieba-blank-after-cursor-p)
      (deno-bridge-jieba-punctuation-char-after-cursor-p))
-    (delete-char 1)
-    (deno-bridge-jieba-kill-word))
+    (delete-char 1))
    ((deno-bridge-jieba-single-char-after-cursor-p)
     (kill-word 1))
    (t (deno-bridge-call-jieba-on-current-line "kill-word"))))
@@ -146,8 +145,7 @@
    ((or
      (deno-bridge-jieba-blank-before-cursor-p)
      (deno-bridge-jieba-punctuation-char-before-cursor-p))
-    (backward-delete-char 1)
-    (deno-bridge-jieba-backward-kill-word))
+    (backward-delete-char 1))
    ((deno-bridge-jieba-single-char-before-cursor-p)
     (backward-kill-word 1))
    (t (deno-bridge-call-jieba-on-current-line "backward-kill-word"))))


### PR DESCRIPTION
当光标周围是空格或者标点符号的时候， 只做单个字符删除， 不再做进一步的单词删除操作。

测试案例：
把光标移动到 https://github.com/manateelazycat/lsp-bridge/blob/8e7f7ad027823044211850bb0a0ed83049e0fcce/README.md#L90 这一行的行为， 向左做 kill-word 操作， 现在的版本会进一步删除单词， 而有时候只是想删除一下空格和逗号的操作反而没法实现。

这个补丁主要是解决了上述问题。